### PR TITLE
add a sentry-msg script to send message to sentry from the shell

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 sentry-wrapper Changelog
 ========================
 
+2.2.0 (2018-11-15)
+------------------
+
+* Add a script which send message to sentry::
+
+  sentry-msg --dsn https://... "my message to send"
+
 2.1.1 (unreleased)
 ------------------
 

--- a/sentry_msg/__init__.py
+++ b/sentry_msg/__init__.py
@@ -1,0 +1,40 @@
+import argparse
+import os
+
+import raven
+
+__version__ = '2.2.0'
+
+
+def execute():
+    """ sentry-wrapper entrypoint.
+    """
+    parser = argparse.ArgumentParser(
+        usage='%(prog)s [options] [message to send]',
+        epilog=('Example: '
+                'sentry-msg --dsn https://... "send me"')
+    )
+
+    parser.add_argument(
+        'msg',
+        help='Message to send'
+    )
+    parser.add_argument(
+        '--dsn', metavar='SENTRY_DSN', default=os.getenv('SENTRY_DSN'),
+        help='Sentry DSN'
+    )
+
+    args = parser.parse_args()
+
+    if args.dsn is None:
+        parser.error('You must provide sentry DSN from the commandline '
+                     'argument --dsn or from the environment variable '
+                     'SENTRY_DSN')
+
+    if args.msg is None:
+        parser.error('Nothing to send')
+
+    sentry_client = raven.Client(args.dsn)
+    sentry_client.captureMessage(args.msg)
+
+    return 0

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     entry_points={
         'console_scripts': [
             'sentry-wrapper = sentry_wrapper:execute',
+            'sentry-msg     = sentry_msg:execute',
         ],
     },
 )


### PR DESCRIPTION
Hello,
This PR add a sentry-msg cli which permit to push some raw message to sentry from the shell. It uses the same env var that sentry-wrapper.